### PR TITLE
Fix security scan workflow - remove SARIF upload

### DIFF
--- a/.github/workflows/automated-deploy.yml
+++ b/.github/workflows/automated-deploy.yml
@@ -39,10 +39,6 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     name: 🔒 Security Scan
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
     
     steps:
     - name: Checkout code
@@ -53,15 +49,7 @@ jobs:
       with:
         scan-type: 'fs'
         scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-
-    - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
-        category: 'trivy'
+        format: 'table'
 
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Remove SARIF upload step that requires Code Scanning to be enabled
- Simplify Trivy scanner to use table format output
- Remove unnecessary permissions for security-events
- Security scan will still run but won't upload results to GitHub Security tab
- This fixes the workflow failure until Code Scanning is properly configured